### PR TITLE
Make rule for ormolu.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,9 @@ tests: $(EXTCURAENGINEBIN)
 	cd tests && for each in `find ./ -name '*.stl' -type f | sort`; do { echo $$each ; ../$(EXTCURAENGINEBIN) slice -l $$each $(RTSOPTS); md5sum out.gcode; } done
 #	$(TESTSUITE)
 
+format:
+	./layout/ormolu.sh -f
+
 # The Hslice library.
 $(LIBTARGET): $(LIBFILES)
 	cabal v2-build ${PROFILING} hslice


### PR DESCRIPTION
Fixes https://github.com/Haskell-Things/hslice/issues/19

I've added the `-f` so it'll work on dirty working copies, but only because I suspect this makes it more useful.  If you like, I'd prefer to remove it.  (Only please don't add to make rules, it's complicated enough as it is.)

Personally I'm not convinced this is a good idea, I'd recommend [using an editor hook](https://github.com/vyorkin/ormolu.el) or making one yourself, or in emergencies call `./layout/ormolu.sh` by hand.