### PR TITLE
Playing with tests

### DIFF
--- a/hslice.cabal
+++ b/hslice.cabal
@@ -77,6 +77,8 @@ Library
                   , slist >=0.2.0.0
                   , Unique
                   , utf8-string
+                  , hspec
+                  , QuickCheck
     Exposed-Modules:
                     Graphics.Slicer
                     Graphics.Slicer.Formats.STL.Definitions

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -28,6 +28,8 @@ import Test.Hspec(hspec, describe)
 -- the execution test for warnings.
 import Math.PGA(contourSpec, lineSpec, linearAlgSpec, geomAlgSpec, pgaSpec, proj2DGeomAlgSpec, facetSpec)
 
+import qualified Graphics.Slicer.Math.Contour (specs)
+
 main :: IO ()
 main = hspec $ do
   -- run tests against the mixed algebra engine.
@@ -41,3 +43,7 @@ main = hspec $ do
   describe "2D PGA operations" pgaSpec
   -- run tests of the facet engine.
   describe "Contour facetization algorithms" facetSpec
+
+  -- experimental new shape for the test suite: have all the tests in the production modules,
+  -- but export only the `specs` to run it here.
+  describe "Graphics.Slicer.Math.Contour" Graphics.Slicer.Math.Contour.specs


### PR DESCRIPTION
A bit of stream of consciousness on what's happening here: when reviewing #42, I got confused and followed an itch to rewrite a few helpers.  Then I wanted to test the new implementation against the old, and found it awkward to have to switch between `/tests` and `/src`, so I started to implement the test suite in the prod modules.  I think this would only increase the binary sizes a little, not runtime performance, while on the other hand moving tests and tested code closer together, which would make it more accessible and easier to handle.  Kinda what I like about doctests.  *Then* I found that the types accomodate illegal values, and the tests fail because of my naive `Arbitrary` instances.  Then I was calculating how much time I have left before I need to take an extensive break from this project again, and grew a bit weary.

So I decided to at least share how far I got.  Maybe you like the idea of testing in prod, and maybe you like my alternative implementations of the helpers.  Please steal any and all of it, or give me a thumbs up and I might get this into a mergeable shape at some point.