### PR TITLE
CI Update

### DIFF
--- a/.github/workflows/ci.dhall
+++ b/.github/workflows/ci.dhall
@@ -4,10 +4,11 @@ in    haskellCi.generalCi
         haskellCi.matrixSteps
         ( Some
             { ghc =
-              [ haskellCi.GHC.GHC8107
+              [ haskellCi.GHC.GHC902
+              , haskellCi.GHC.GHC8107
               , haskellCi.GHC.GHC884
               ]
-            , cabal = [ haskellCi.Cabal.Cabal32 ]
+            , cabal = [ haskellCi.Cabal.Cabal34 ]
             }
         )
         // { on = [ haskellCi.Event.push

--- a/.github/workflows/ci.dhall
+++ b/.github/workflows/ci.dhall
@@ -4,7 +4,7 @@ in    haskellCi.generalCi
         haskellCi.matrixSteps
         ( Some
             { ghc =
-              [ haskellCi.GHC.GHC8104
+              [ haskellCi.GHC.GHC8107
               , haskellCi.GHC.GHC884
               ]
             , cabal = [ haskellCi.Cabal.Cabal32 ]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,8 +35,9 @@ jobs:
     strategy:
       matrix:
         cabal:
-          - '3.2'
+          - '3.4'
         ghc:
+          - '9.0.2'
           - '8.10.7'
           - '8.8.4'
 name: Haskell CI

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: "actions/checkout@v1"
+      - uses: "actions/checkout@v3"
       - id: setup-haskell-cabal
-        uses: "haskell/actions/setup@v1.2"
+        uses: "haskell/actions/setup@v2"
         with:
           cabal-version: "${{ matrix.cabal }}"
           enable-stack: false
@@ -18,10 +18,12 @@ jobs:
           fi
       - name: freeze
         run: cabal freeze
-      - uses: "actions/cache@v2"
+      - uses: "actions/cache@v3"
         with:
           key: "${{ runner.os }}-${{ matrix.ghc }}-cabal-${{ hashFiles('cabal.project.freeze') }}"
-          path: "${{ steps.setup-haskell-cabal.outputs.cabal-store }} dist-newstyle"
+          path: |
+            ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
+            dist-newstyle
       - name: Install dependencies
         run: cabal build all --enable-tests --enable-benchmarks --only-dependencies
       - name: build all
@@ -35,7 +37,7 @@ jobs:
         cabal:
           - '3.2'
         ghc:
-          - '8.10.4'
+          - '8.10.7'
           - '8.8.4'
 name: Haskell CI
 on:


### PR DESCRIPTION
GHC9 complains 
```
Error:     Pattern match is redundant
    In a case alternative: (Slist [] _) -> ...
   |
67 |                             (Slist [] _) -> error "looking for a first ENode in an empty ENodeSet."
   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

But looking at the code I don't see how it finds it redundant.